### PR TITLE
Fix spelling of 'destroy' in reference.jsx

### DIFF
--- a/app/_components/reference.jsx
+++ b/app/_components/reference.jsx
@@ -56,9 +56,9 @@ const api2 = [
   ['context.readTensor', 'webnn/mlcontext#readtensor'],
   ['context.writeTensor', 'webnn/mlcontext#writetensor'],
   ['context.opSupportLimits', 'webnn/mlcontext#opsupportlimits'],
-  ['context.destory', 'webnn/mlcontext#destroy'],
-  ['graph.destory', 'webnn/mlgraph#destroy'],
-  ['tensor.destory', 'webnn/mltensor#destroy'],
+  ['context.destroy', 'webnn/mlcontext#destroy'],
+  ['graph.destroy', 'webnn/mlgraph#destroy'],
+  ['tensor.destroy', 'webnn/mltensor#destroy'],
   ['builder.input', 'webnn/mlgraphbuilder#input'],
   ['builder.constant', 'webnn/mlgraphbuilder#constant'],
   ['builder.build', 'webnn/mlgraphbuilder#build']


### PR DESCRIPTION
Corrected spelling of 'destroy'. @ibelem
https://webnn.io/en/api-reference/reference

<img width="861" height="355" alt="image" src="https://github.com/user-attachments/assets/f3fbdce8-1f2a-41a1-b606-07ea1fd29921" />